### PR TITLE
Automate npm publishing with trusted OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish npm package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: ${{ !github.event.release.prerelease && startsWith(github.event.release.tag_name, 'v') }}
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Use an OIDC-capable npm CLI
+        run: npm install --global npm@11
+
+      - name: Install package metadata
+        run: npm ci --ignore-scripts
+
+      - name: Run portable tests
+        run: npm test
+
+      - name: Verify version and archive checksum
+        run: npm run verify-publish
+
+      - name: Verify the signed universal app
+        shell: bash
+        run: |
+          set -euo pipefail
+          verify_dir="$(mktemp -d "$RUNNER_TEMP/mmf27-release.XXXXXX")"
+          /usr/bin/ditto -x -k "dist/MMF27-Dock-Swipe-Fix-${GITHUB_REF_NAME#v}.app.zip" "$verify_dir"
+          app="$verify_dir/MMF27 Dock Swipe Fix.app"
+          executable="$app/Contents/MacOS/MMF27DockSwipeFix"
+          /usr/bin/codesign --verify --deep --strict --verbose=2 "$app"
+          signature="$(/usr/bin/codesign -dv --verbose=4 "$app" 2>&1)"
+          grep -F "Identifier=local.timmy.mmf27-dock-swipe-fix" <<<"$signature"
+          grep -F "TeamIdentifier=4356B4HF9R" <<<"$signature"
+          grep -F "Authority=Developer ID Application: TINGJUN ZHOU (4356B4HF9R)" <<<"$signature"
+          architectures="$(/usr/bin/lipo -archs "$executable")"
+          [[ " $architectures " == *" arm64 "* ]]
+          [[ " $architectures " == *" x86_64 "* ]]
+          version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Contents/Info.plist")"
+          [[ "v$version" == "$GITHUB_REF_NAME" ]]
+
+      - name: Publish with npm Trusted Publishing
+        run: npm publish --ignore-scripts --access public

--- a/README.md
+++ b/README.md
@@ -395,6 +395,12 @@ event alone.
 - Uses private SkyLight/HID APIs, so this should be treated as a temporary
   compatibility repair rather than a permanent system extension
 
+Maintainer releases use npm Trusted Publishing through the repository's
+`publish.yml` GitHub Actions workflow. npm authenticates that exact workflow
+with short-lived OIDC credentials, so future releases need no saved npm write
+token or repeated interactive 2FA prompt. The package's Trusted Publisher must
+remain bound to `timmyagentic/mac-mouse-fix-macos-27-fix` and `publish.yml`.
+
 ### Compatibility
 
 Designed and self-tested on macOS 27 with Mac Mouse Fix 3.1.0 Beta 1. Mac Mouse
@@ -670,6 +676,11 @@ velocity，并通过 `SLEventSetIOHIDEvent` 附加到原事件。
   两种 CPU 架构以及内置 HID 自检
 - 仓库包含完整源码和可在本机构建的脚本
 - 使用 SkyLight/HID 私有 API，因此它应该被视为临时兼容性修复，而不是永久系统扩展
+
+维护者发布使用仓库 `publish.yml` GitHub Actions 工作流提供的 npm Trusted
+Publishing。npm 会通过短期 OIDC 凭据验证这个精确工作流，因此后续版本不需要保存 npm
+写入 Token，也不需要每次交互式完成 2FA。npm 包的 Trusted Publisher 设置必须继续绑定
+`timmyagentic/mac-mouse-fix-macos-27-fix` 和 `publish.yml`。
 
 ### 兼容性
 

--- a/README.md
+++ b/README.md
@@ -395,11 +395,12 @@ event alone.
 - Uses private SkyLight/HID APIs, so this should be treated as a temporary
   compatibility repair rather than a permanent system extension
 
-Maintainer releases use npm Trusted Publishing through the repository's
-`publish.yml` GitHub Actions workflow. npm authenticates that exact workflow
-with short-lived OIDC credentials, so future releases need no saved npm write
-token or repeated interactive 2FA prompt. The package's Trusted Publisher must
-remain bound to `timmyagentic/mac-mouse-fix-macos-27-fix` and `publish.yml`.
+After the one-time npm-side Trusted Publisher setup, future maintainer releases
+use the repository's `publish.yml` GitHub Actions workflow. npm authenticates
+that exact workflow with short-lived OIDC credentials, so releases need no
+saved npm write token or repeated interactive 2FA prompt. The package's Trusted
+Publisher must remain bound to `timmyagentic/mac-mouse-fix-macos-27-fix` and
+`publish.yml`.
 
 ### Compatibility
 
@@ -677,10 +678,11 @@ velocity，并通过 `SLEventSetIOHIDEvent` 附加到原事件。
 - 仓库包含完整源码和可在本机构建的脚本
 - 使用 SkyLight/HID 私有 API，因此它应该被视为临时兼容性修复，而不是永久系统扩展
 
-维护者发布使用仓库 `publish.yml` GitHub Actions 工作流提供的 npm Trusted
-Publishing。npm 会通过短期 OIDC 凭据验证这个精确工作流，因此后续版本不需要保存 npm
-写入 Token，也不需要每次交互式完成 2FA。npm 包的 Trusted Publisher 设置必须继续绑定
-`timmyagentic/mac-mouse-fix-macos-27-fix` 和 `publish.yml`。
+在 npm 侧完成一次性 Trusted Publisher 设置后，后续维护者发布会使用仓库
+`publish.yml` GitHub Actions 工作流。npm 会通过短期 OIDC 凭据验证这个精确工作流，
+因此发布时不需要保存 npm 写入 Token，也不需要每次交互式完成 2FA。npm 包的 Trusted
+Publisher 设置必须继续绑定 `timmyagentic/mac-mouse-fix-macos-27-fix` 和
+`publish.yml`。
 
 ### 兼容性
 

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
   "files": [
     "bin/",
     "lib/",
+    "scripts/verify-publish.js",
     "dist/MMF27-Dock-Swipe-Fix-0.3.0.app.zip",
     "release-manifest.json"
   ],
   "scripts": {
     "test": "node --test",
-    "check": "npm test && node ./bin/mmf27-fix.js --help && npm run verify-release && npm pack --dry-run",
+    "check": "npm test && node ./bin/mmf27-fix.js --help && npm run verify-publish && npm run verify-release && npm pack --dry-run",
+    "verify-publish": "node ./scripts/verify-publish.js",
     "verify-release": "node ./bin/mmf27-fix.js verify-release",
     "prepublishOnly": "npm run check"
   },

--- a/scripts/verify-publish.js
+++ b/scripts/verify-publish.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+const [packageContents, manifestContents] = await Promise.all([
+  readFile(path.join(projectRoot, "package.json"), "utf8"),
+  readFile(path.join(projectRoot, "release-manifest.json"), "utf8"),
+]);
+const packageJSON = JSON.parse(packageContents);
+const manifest = JSON.parse(manifestContents);
+
+assert(
+  packageJSON.name === "mmf27-dock-swipe-fix",
+  `Unexpected package name: ${packageJSON.name}`,
+);
+assert(
+  manifest.appVersion === packageJSON.version,
+  `App version ${manifest.appVersion} does not match package ${packageJSON.version}`,
+);
+assert(
+  manifest.releaseTag === `v${packageJSON.version}`,
+  `Release tag ${manifest.releaseTag} does not match package ${packageJSON.version}`,
+);
+if (process.env.GITHUB_REF_NAME) {
+  assert(
+    process.env.GITHUB_REF_NAME === manifest.releaseTag,
+    `Workflow ref ${process.env.GITHUB_REF_NAME} does not match ${manifest.releaseTag}`,
+  );
+}
+
+const archivePath = path.resolve(projectRoot, manifest.archive);
+assert(
+  archivePath.startsWith(`${projectRoot}${path.sep}`),
+  "Release archive escapes the project root",
+);
+assert(
+  packageJSON.files?.includes(manifest.archive),
+  `npm package files do not include ${manifest.archive}`,
+);
+const archive = await readFile(archivePath);
+const actualSHA256 = createHash("sha256").update(archive).digest("hex");
+assert(
+  actualSHA256 === manifest.sha256,
+  `Archive SHA-256 ${actualSHA256} does not match ${manifest.sha256}`,
+);
+
+console.log(
+  `PASS: ${manifest.releaseTag} package metadata and SHA-256 are consistent.`,
+);


### PR DESCRIPTION
## Summary

- publish future non-prerelease GitHub Releases to npm with Trusted Publishing/OIDC
- verify tag, package/app version, archive SHA-256, Developer ID signature, Team ID, bundle ID, and universal architectures before publishing
- document the one-time npm Trusted Publisher binding in English and Chinese

## Verification

- `npm run check` (12/12 tests plus signed universal release verification)
- `npm pack --dry-run`
- `git diff --check`
- public npm registry confirms `mmf27-dock-swipe-fix@0.3.0` is `latest`

After this workflow lands, npm is bound once to `timmyagentic/mac-mouse-fix-macos-27-fix` + `publish.yml` with publish permission. Future releases then use short-lived GitHub OIDC credentials instead of an npm write token or repeated interactive 2FA.
